### PR TITLE
Add relative root path

### DIFF
--- a/bin/octodown
+++ b/bin/octodown
@@ -11,10 +11,7 @@ OptionParser.new do |opts|
   opts.banner = 'Usage: octodown [options]'
 
   opts.on(
-    '-s',
-    '--style [STYLE]',
-    [:github, :atom],
-    'Choose style (atom, github)'
+    '-s', '--style [STYLE]', [:github, :atom], 'Choose style (atom, github)'
   ) do |s|
     options[:style] = s
   end
@@ -32,15 +29,15 @@ end.parse!
 def main(options)
   include Octodown::Support
 
-  input_contents = ARGF.read
+  content = ARGF.read
   style = options[:style] || 'github'
+  path = File.dirname(File.expand_path(ARGF.path))
 
   if options[:raw]
-    puts Helpers.markdown_to_raw_html input_contents, style
+    puts Helpers.markdown_to_raw_html content, style, path
   else
-    browser = Browser.new
-    html_file = Helpers.markdown_to_html input_contents, style
-    browser.open html_file
+    html_file = Helpers.markdown_to_html content, style, path
+    Browser.new.open html_file
   end
 end
 

--- a/lib/octodown.rb
+++ b/lib/octodown.rb
@@ -2,6 +2,7 @@ require 'octodown/renderer/github_markdown'
 require 'octodown/renderer/html'
 require 'octodown/support/browser'
 require 'octodown/support/helpers'
+require 'octodown/support/relative_root_filter'
 require 'octodown/support/html_file'
 require 'octodown/version'
 

--- a/lib/octodown/renderer/github_markdown.rb
+++ b/lib/octodown/renderer/github_markdown.rb
@@ -5,10 +5,11 @@ require 'html/pipeline'
 module Octodown
   module Renderer
     class GithubMarkdown
-      attr_reader :content
+      attr_reader :content, :document_root
 
-      def initialize(content)
+      def initialize(content, document_root)
         @content = content
+        @document_root = document_root
       end
 
       def to_html
@@ -18,12 +19,16 @@ module Octodown
       private
 
       def context
-        { :asset_root => 'https://assets-cdn.github.com/images/icons/' }
+        {
+          :asset_root => 'https://assets-cdn.github.com/images/icons/',
+          :original_document_root => document_root
+        }
       end
 
       def pipeline
         ::HTML::Pipeline.new [
           ::HTML::Pipeline::MarkdownFilter,
+          ::Octodown::Support::RelativeRootFilter,
           ::HTML::Pipeline::SanitizationFilter,
           ::HTML::Pipeline::ImageMaxWidthFilter,
           ::HTML::Pipeline::MentionFilter,

--- a/lib/octodown/support/helpers.rb
+++ b/lib/octodown/support/helpers.rb
@@ -1,16 +1,18 @@
 module Octodown
   module Support
     module Helpers
+      include Octodown::Renderer
+
       # TODO: Find a better home for this logic
-      def self.markdown_to_html(contents, template)
-        html = markdown_to_raw_html(contents, template)
+      def self.markdown_to_html(content, template, path)
+        html = markdown_to_raw_html(content, template, path)
         tmp = Octodown::Support::HTMLFile.new 'octodown'
         tmp.persistent_write html
       end
 
-      def self.markdown_to_raw_html(contents, template)
-        unstyled_html = Octodown::Renderer::GithubMarkdown.new(contents).to_html
-        Octodown::Renderer::HTML.new(unstyled_html, template).render
+      def self.markdown_to_raw_html(content, template, path)
+        unstyled_html = GithubMarkdown.new(content, path).to_html
+        HTML.new(unstyled_html, template).render
       end
     end
   end

--- a/lib/octodown/support/relative_root_filter.rb
+++ b/lib/octodown/support/relative_root_filter.rb
@@ -1,0 +1,28 @@
+require 'uri'
+
+module Octodown
+  module Support
+    class RelativeRootFilter < HTML::Pipeline::Filter
+      def call
+        doc.search('img').each do |img|
+          next if img['src'].nil?
+
+          src = img['src'].strip
+
+          img['src'] = relative_path_from_document_root src unless http_uri? src
+        end
+
+        doc
+      end
+
+      def relative_path_from_document_root(src)
+        File.join(context[:original_document_root], src).to_s
+      end
+
+      def http_uri?(src)
+        parsed_uri = URI.parse src
+        parsed_uri.is_a? URI::HTTP
+      end
+    end
+  end
+end

--- a/spec/markdown_generation_spec.rb
+++ b/spec/markdown_generation_spec.rb
@@ -3,7 +3,7 @@ require 'tempfile'
 describe Octodown::Renderer::GithubMarkdown do
   let(:dummy_path) { File.join(File.dirname(__FILE__), 'dummy', 'test.md') }
   let(:html) do
-    Octodown::Renderer::GithubMarkdown.new(File.read(dummy_path)).to_html
+    Octodown::Renderer::GithubMarkdown.new(File.read(dummy_path), 'tmp').to_html
   end
 
   it 'create HTML from markdown file' do

--- a/spec/relative_root_filter_spec.rb
+++ b/spec/relative_root_filter_spec.rb
@@ -1,0 +1,14 @@
+require 'tempfile'
+
+describe Octodown::Renderer::GithubMarkdown do
+  subject { Octodown::Support::RelativeRootFilter.new(nil) }
+
+  it 'detects an non-HTTP/HTTPS URI correctly' do
+    expect(subject.http_uri?('assets/test.png')).to eq false
+  end
+
+  it 'detects HTTP/HTTPS URI correctly' do
+    expect(subject.http_uri?('http://foo.com/assets/test.png')).to eq true
+    expect(subject.http_uri?('https://foo.com/assets/test.png')).to eq true
+  end
+end

--- a/spec/template_rendering_spec.rb
+++ b/spec/template_rendering_spec.rb
@@ -3,7 +3,7 @@ require 'tempfile'
 describe Octodown::Renderer::HTML do
   let(:dummy_path) { File.join(File.dirname(__FILE__), 'dummy', 'test.md') }
   let(:html) do
-    Octodown::Renderer::GithubMarkdown.new(File.read(dummy_path)).to_html
+    Octodown::Renderer::GithubMarkdown.new(File.read(dummy_path), 'tmp').to_html
   end
 
   subject { Octodown::Renderer::HTML.new(html, 'github').render }


### PR DESCRIPTION
This fixes an issue where local images would not render correctly in the browser. Only HTTP (external) images would be shown. This adds a step in the HTML pipeline which checks to see if the image is HTTP/HTTPS. If it is not, it assumes that the file is local, then rewrites the path to be relative to the *original* document root, not where the rendered file is located (some tmp dir).