### PR TITLE
Allow user to specify whether to use gfm

### DIFF
--- a/bin/octodown
+++ b/bin/octodown
@@ -20,6 +20,10 @@ OptionParser.new do |opts|
     options[:raw] = r
   end
 
+  opts.on('-g', '--[no-]gfm', 'Use for non-README files (comments, etc)') do |g|
+    options[:gfm] = g
+  end
+
   opts.on_tail('-h', '--help', 'Show this message') do
     puts opts
     exit
@@ -30,13 +34,12 @@ def main(options)
   include Octodown::Support
 
   content = ARGF.read
-  style = options[:style] || 'github'
   path = File.dirname(File.expand_path(ARGF.path))
 
   if options[:raw]
-    puts Helpers.markdown_to_raw_html content, style, path
+    puts Helpers.markdown_to_raw_html content, options, path
   else
-    html_file = Helpers.markdown_to_html content, style, path
+    html_file = Helpers.markdown_to_html content, options, path
     Browser.new.open html_file
   end
 end

--- a/lib/octodown/renderer/github_markdown.rb
+++ b/lib/octodown/renderer/github_markdown.rb
@@ -5,11 +5,12 @@ require 'html/pipeline'
 module Octodown
   module Renderer
     class GithubMarkdown
-      attr_reader :content, :document_root
+      attr_reader :content, :document_root, :gfm
 
-      def initialize(content, document_root)
+      def initialize(content, document_root, options = {})
         @content = content
         @document_root = document_root
+        @gfm = options[:gfm] || false
       end
 
       def to_html
@@ -34,7 +35,7 @@ module Octodown
           ::HTML::Pipeline::MentionFilter,
           ::HTML::Pipeline::EmojiFilter,
           ::HTML::Pipeline::SyntaxHighlightFilter
-        ], context.merge(:gfm => true)
+        ], context.merge(:gfm => gfm)
       end
     end
   end

--- a/lib/octodown/renderer/html.rb
+++ b/lib/octodown/renderer/html.rb
@@ -3,11 +3,11 @@ require 'erb'
 module Octodown
   module Renderer
     class HTML
-      attr_reader :rendered_markdown, :template
+      attr_reader :rendered_markdown, :style
 
-      def initialize(rendered_markdown, template)
+      def initialize(rendered_markdown, options)
         @rendered_markdown = rendered_markdown
-        @template = template
+        @style = options[:style] || 'github'
       end
 
       def render
@@ -24,7 +24,7 @@ module Octodown
         stylesheet_file = File.join(
           Octodown.root,
           'assets',
-          "#{template}.css"
+          "#{style}.css"
         )
 
         File.read stylesheet_file

--- a/lib/octodown/support/helpers.rb
+++ b/lib/octodown/support/helpers.rb
@@ -4,15 +4,15 @@ module Octodown
       include Octodown::Renderer
 
       # TODO: Find a better home for this logic
-      def self.markdown_to_html(content, template, path)
-        html = markdown_to_raw_html(content, template, path)
+      def self.markdown_to_html(content, options, path)
+        html = markdown_to_raw_html(content, options, path)
         tmp = Octodown::Support::HTMLFile.new 'octodown'
         tmp.persistent_write html
       end
 
-      def self.markdown_to_raw_html(content, template, path)
-        unstyled_html = GithubMarkdown.new(content, path).to_html
-        HTML.new(unstyled_html, template).render
+      def self.markdown_to_raw_html(content, options, path)
+        rendered_markdown = GithubMarkdown.new(content, path, options).to_html
+        HTML.new(rendered_markdown, options).render
       end
     end
   end

--- a/spec/dummy/test.md
+++ b/spec/dummy/test.md
@@ -1,4 +1,7 @@
-# Hello world!
+Hello world!
+============
+![some-img](https://foo.com/bar.img)
+![some-img](https://foo.com/bar.img)
 
 You are now reading markdown. How lucky you are!
 

--- a/spec/markdown_generation_spec.rb
+++ b/spec/markdown_generation_spec.rb
@@ -2,8 +2,9 @@ require 'tempfile'
 
 describe Octodown::Renderer::GithubMarkdown do
   let(:dummy_path) { File.join(File.dirname(__FILE__), 'dummy', 'test.md') }
+  let(:content) { File.read dummy_path }
   let(:html) do
-    Octodown::Renderer::GithubMarkdown.new(File.read(dummy_path), 'tmp').to_html
+    Octodown::Renderer::GithubMarkdown.new(content, 'tmp').to_html
   end
 
   it 'create HTML from markdown file' do
@@ -15,5 +16,23 @@ describe Octodown::Renderer::GithubMarkdown do
 
   it 'highlights the code' do
     expect(html).to include 'highlight-ruby'
+  end
+
+  describe 'when :gfm option is set' do
+    context 'true' do
+      it 'renders hard-wraps' do
+        options = { :gfm => true }
+        doc = Octodown::Renderer::GithubMarkdown.new(content, 'tmp', options)
+        expect(doc.to_html).to include '<br>'
+      end
+    end
+
+    context 'false' do
+      it 'does not render hard-wraps' do
+        options = { :gfm => false }
+        doc = Octodown::Renderer::GithubMarkdown.new(content, 'tmp', options)
+        expect(doc.to_html).to_not include '<br>'
+      end
+    end
   end
 end

--- a/spec/template_rendering_spec.rb
+++ b/spec/template_rendering_spec.rb
@@ -2,11 +2,12 @@ require 'tempfile'
 
 describe Octodown::Renderer::HTML do
   let(:dummy_path) { File.join(File.dirname(__FILE__), 'dummy', 'test.md') }
+  let(:options) { { style: 'github' } }
   let(:html) do
     Octodown::Renderer::GithubMarkdown.new(File.read(dummy_path), 'tmp').to_html
   end
 
-  subject { Octodown::Renderer::HTML.new(html, 'github').render }
+  subject { Octodown::Renderer::HTML.new(html, options).render }
 
   before { allow(Octodown).to receive(:root) { '.' } }
 


### PR DESCRIPTION
By default, Github does not render README.md files using Github-flavored
markdown. This causes for a bug in Octodown rendering where images would have
`<br>` tags where they should not, amongst other issues. To fix this, we specify an option which
the user can set: `--[no-]gfm`. This option defaults to setting `:gfm` to false,
assuming that rendering README.md would be the most common use-case. This can later be a
adapted to auto-detect and set `:gfm` setting by filename if that is desired.