### PR TITLE
Create default rake tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ before_install:
     - sudo apt-get install -y libicu-dev build-essential
 install: 'bundle install'
 script:
-  - 'bundle exec rspec --format documentation'
-  - 'bundle exec rubocop'
+  - bundle exec rake
 rvm:
   - '2.2.0'
   - '2.1.4'

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,16 @@ require 'bundler/gem_tasks'
 require 'open-uri'
 require 'fileutils'
 require 'tempfile'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+RSpec::Core::RakeTask.new :spec do |task|
+  task.rspec_opts = '--format documentation'
+end
+
+task :default => [:spec, :rubocop]
 
 task :styles do
   begin


### PR DESCRIPTION
This PR adds a default `rake` task to run the test suite and syntax checkers.
This will be useful for those wishing to see if their changes play well with
the CI build.