### PR TITLE
Add HTTP server support with Rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       html-pipeline (~> 1.11.0)
       launchy (~> 2.4.3)
       pygments.rb (~> 0.6.0)
+      rack (~> 1.6.0)
       sanitize (~> 3.1.0)
 
 GEM
@@ -63,6 +64,9 @@ GEM
     pygments.rb (0.6.2)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
+    rack (1.6.0)
+    rack-test (0.6.3)
+      rack (>= 1.0)
     rainbow (2.0.0)
     rake (10.4.2)
     rspec (3.1.0)
@@ -85,7 +89,7 @@ GEM
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.1)
     rugged (0.22.0b5)
-    sanitize (3.1.0)
+    sanitize (3.1.1)
       crass (~> 1.0.1)
       nokogiri (>= 1.4.4)
       nokogumbo (= 1.2.0)
@@ -111,6 +115,7 @@ DEPENDENCIES
   octodown!
   octokit
   posix-spawn (= 0.3.9)
+  rack-test (~> 0.6.3)
   rake (~> 10.0)
   rspec (~> 3.1.0)
   rubocop (~> 0.28.0)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ primary goal to reproduce it as faithfully as possible.
 - Properly parses `STDIN`.
   - `cat README.md | octodown`
 
+  - Serves file with an HTTP server
+    - `octodown -S README.md`
+
 ## Installation
 
 1. Install `icu4c` and `cmake`:
@@ -62,6 +65,9 @@ primary goal to reproduce it as faithfully as possible.
 
 1. *nix lovers:
   - `echo '# Hello world!' | octodown --raw > index.html`
+
+  4. Live preview at `http://localhost:4567`:
+    - `octodown README.md --server --port 4567`
 
 ## Notes
 

--- a/bin/octodown
+++ b/bin/octodown
@@ -30,6 +30,16 @@ OptionParser.new do |opts|
     options[:gfm] = g
   end
 
+  opts.on('-S', '--server', 'Start a web server') do
+    options[:server] = true
+  end
+
+  opts.on('-P', '--port [PORT]', 'Server port (default: ' \
+          "#{Octodown::Support::Server::DEFAULT_PORT})") do |port|
+    options[:server] = true
+    options[:port] = port.to_i
+  end
+
   opts.on_tail('-h', '--help', 'Show this message') do
     puts opts
     exit
@@ -44,6 +54,9 @@ def main(options)
 
   if options[:raw]
     puts Helpers.markdown_to_raw_html content, options, path
+  elsif options[:server]
+    server = Server.new content, options, path
+    server.start
   else
     html_file = Helpers.markdown_to_html content, options, path
     Launchy.open html_file.path

--- a/lib/octodown.rb
+++ b/lib/octodown.rb
@@ -3,6 +3,7 @@ require 'octodown/renderer/html'
 require 'octodown/support/helpers'
 require 'octodown/support/relative_root_filter'
 require 'octodown/support/html_file'
+require 'octodown/support/server'
 require 'octodown/version'
 
 module Octodown

--- a/lib/octodown/support/server.rb
+++ b/lib/octodown/support/server.rb
@@ -1,0 +1,51 @@
+module Octodown
+  module Support
+    class Server
+      DEFAULT_PORT = 8080
+
+      def initialize(content, options, path)
+        require 'rack'
+
+        @content = content
+        @options = options
+        @path = path
+      end
+
+      def start
+        Rack::Server.start(app: app, Port: port)
+      end
+
+      def call(env)
+        res = Rack::Response.new
+        res.headers['Content-Type'] = 'text/html'
+
+        if env['PATH_INFO'] == '/'
+          res.write(body) if env['REQUEST_METHOD'] == 'GET'
+        else
+          res.status = 404
+        end
+
+        res.finish
+      end
+
+      def app
+        # Cascade through this app and Rack::File app.
+        # If Server returns 404, Rack::File will try to serve a static file.
+        @app ||= Rack::Cascade.new([self, Rack::File.new(@path)])
+      end
+
+      private
+
+      def body
+        # Render HTML body from Markdown
+        # Use / as document root to generate URLs with relative paths
+        Octodown::Support::Helpers
+          .markdown_to_raw_html(@content, @options, '/')
+      end
+
+      def port
+        @options[:port] || DEFAULT_PORT
+      end
+    end
+  end # Support
+end # Octodown

--- a/octodown.gemspec
+++ b/octodown.gemspec
@@ -24,10 +24,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gemoji',              '~> 2.1.0'
   spec.add_dependency 'pygments.rb',         '~> 0.6.0'
   spec.add_dependency 'launchy',             '~> 2.4.3'
+  spec.add_dependency 'rack',                '~> 1.6.0'
 
   spec.add_development_dependency 'rspec',   '~> 3.1.0'
   spec.add_development_dependency 'rubocop', '~> 0.28.0'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake',    '~> 10.0'
+  spec.add_development_dependency 'rack-test', '~> 0.6.3'
   spec.add_development_dependency 'octokit'
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,0 +1,36 @@
+require 'rack/test'
+require 'octodown'
+
+describe Octodown::Support::Server do
+  include Rack::Test::Methods
+
+  let(:dummy_path) { File.join(File.dirname(__FILE__), 'dummy', 'test.md') }
+  let(:content) { File.read dummy_path }
+  let(:server) { Octodown::Support::Server.new(content, {}, dummy_path) }
+  let(:app) { server.app }
+
+  it 'serves a Rack app' do
+    expect(Rack::Server).to receive(:start)
+      .with(app: app, Port: Octodown::Support::Server::DEFAULT_PORT)
+    server.start
+  end
+
+  it 'generates HTML for each request' do
+    get '/'
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to include '<h1>Hello world!</h1>'
+  end
+
+  context 'with option :port' do
+    let(:server) do
+      Octodown::Support::Server.new(content, { port: 4567 }, dummy_path)
+    end
+
+    it 'serves in the specified port' do
+      expect(Rack::Server).to receive(:start)
+        .with(app: app, Port: 4567)
+      server.start
+    end
+  end
+end


### PR DESCRIPTION
Hi! I thought it could be useful to have the possibility of starting up a small web server to serve a Markdown file, instead of generating to stdout or a file (like the `yard server` option in the YARD documentation gem). The advantage is that on each request the HTML is rebuilt, so you can preview immediately any changes you make on the original file.

```bash
$ octodown --server README.md 
[2015-01-15 00:00:13] INFO  WEBrick 1.3.1
[2015-01-15 00:00:13] INFO  ruby 2.1.5 (2014-11-13) [x86_64-linux]
[2015-01-15 00:00:13] INFO  WEBrick::HTTPServer#start: pid=28265 port=8080
localhost - - [15/Jan/2015:00:02:44 ART] "GET / HTTP/1.1" 200 22543
- -> /
```

```bash
$ curl -s http://localhost:8080/ | head -n8
<!DOCTYPE html>

<html>
  <head>
    <meta charset="utf-8">
    <title>Octodown Preview</title>
    <link rel="shortcut icon" href="https://raw.githubusercontent.com/ianks/octodown/master/assets/favicon.png" type="image/png" />
    <style>
```
What do you think?