### PR TITLE
Add an html extension to the temp file

### DIFF
--- a/lib/octodown/support/helpers.rb
+++ b/lib/octodown/support/helpers.rb
@@ -6,7 +6,7 @@ module Octodown
       # TODO: Find a better home for this logic
       def self.markdown_to_html(content, options, path)
         html = markdown_to_raw_html(content, options, path)
-        tmp = Octodown::Support::HTMLFile.new 'octodown'
+        tmp = Octodown::Support::HTMLFile.new ['octodown', '.html']
         tmp.persistent_write html
       end
 


### PR DESCRIPTION
An extension can be added to the temp file (created behind the scene by `Tempfile.new`). It helps Safari recognize that the file is an HTML document.

It is a possible solution for  https://github.com/ianks/octodown/issues/34