### PR TITLE
Create ridiculous bash script to properly get realpath in OSX

### DIFF
--- a/packaging/wrapper.sh
+++ b/packaging/wrapper.sh
@@ -1,9 +1,28 @@
 #!/bin/bash
+
 set -e
 
+TARGET_FILE=$0
+
+cd `dirname $TARGET_FILE`
+TARGET_FILE=`basename $TARGET_FILE`
+
+# Iterate down a (possible) chain of symlinks
+while [ -L "$TARGET_FILE" ]
+do
+    TARGET_FILE=`readlink $TARGET_FILE`
+    cd `dirname $TARGET_FILE`
+    TARGET_FILE=`basename $TARGET_FILE`
+done
+
+# Compute the canonicalized name by finding the physical path
+# for the directory we're in and appending the target file.
+PHYS_DIR=`pwd -P`
+RESULT=$PHYS_DIR/$TARGET_FILE
+
 # Figure out where this script is located.
-SELFDIR="`dirname \"$0\"`"
-SELFDIR="`cd \"$SELFDIR\" && pwd`"
+SELFDIR=$(dirname "$RESULT")
+
 
 # Tell Bundler where the Gemfile and gems are.
 export BUNDLE_GEMFILE="$SELFDIR/lib/app/Gemfile"


### PR DESCRIPTION
This is all in preparation for the Homebrew formula. Apparently, `readlink`'s implementation on OSX is buggy to the point where it warrants this hacky mess. If anyone knows a better way to properly deference a symbolic link to get the absolute path in OSX bash, holler.