### PR TITLE
Rescue URI parsing exceptions [resolves #53]

### DIFF
--- a/lib/octodown/support/relative_root_filter.rb
+++ b/lib/octodown/support/relative_root_filter.rb
@@ -19,7 +19,12 @@ module Octodown
       end
 
       def http_uri?(src)
-        parsed_uri = URI.parse src
+        parsed_uri = begin
+          URI.parse src
+        rescue
+          src
+        end
+
         parsed_uri.is_a? URI::HTTP
       end
 

--- a/spec/relative_root_filter_spec.rb
+++ b/spec/relative_root_filter_spec.rb
@@ -6,6 +6,10 @@ describe Octodown::Renderer::GithubMarkdown do
   # Testing private methods because Nokogirl is a black box
   it 'detects an non-HTTP/HTTPS URI correctly' do
     expect(subject.send(:http_uri?, 'assets/test.png')).to eq false
+    expect(subject.send(
+      :http_uri?,
+      '#array#bsearch-vs-array#find-codecodearraybsearch-vs-findrb'
+    )).to eq false
   end
 
   it 'detects HTTP/HTTPS URI correctly' do


### PR DESCRIPTION
This resolves any issue where attempting to parse a URL would resolve in an exception. For example, previously trying to URI such as `#array#bsearch-vs-array#find-codecodearraybsearch-vs-findrb` would result in a error.