### PR TITLE
Download native extensions and remove dead files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,14 @@ Distribution.configure do |config|
   config.version = Octodown::VERSION
   config.rb_version = '20150130-2.1.5'
   config.packaging_dir = "#{Octodown.root}/packaging"
+  config.native_extensions = [
+    'rugged-0.21.4',
+    'posix-spawn-0.3.9',
+    'nokogumbo-1.3.0',
+    'github-markdown-0.6.8',
+    'escape_utils-1.0.1',
+    'charlock_holmes-0.7.3'
+  ]
 end
 
 task :default => [:spec, :rubocop]

--- a/tasks/distrubution/configuration.rb
+++ b/tasks/distrubution/configuration.rb
@@ -9,6 +9,7 @@ module Distribution
   end
 
   class Configuration
-    attr_accessor :package_name, :packaging_dir, :version, :rb_version
+    attr_accessor :package_name, :packaging_dir, :version, :rb_version,
+                  :native_extensions
   end
 end

--- a/tasks/distrubution/package.rb
+++ b/tasks/distrubution/package.rb
@@ -12,7 +12,7 @@ module Distribution
     attr_reader :config, :dir, :tarball, :package, :arch
 
     def_delegators :@config, :version, :rb_version, :package_name,
-                   :packaging_dir
+                   :packaging_dir, :native_extensions
 
     def initialize(arch)
       abort 'Ruby 2.1.x required' if RUBY_VERSION !~ /^2\.1\./

--- a/tasks/distrubution/tarball.rb
+++ b/tasks/distrubution/tarball.rb
@@ -29,6 +29,8 @@ module Distribution
       FileUtils.mkdir_p 'distro'
       system "tar -czf distro/#{dir}.tar.gz #{dir} > /dev/null"
       FileUtils.remove_dir "#{dir}", true
+
+      File.new "distro/#{dir}.tar.gz"
     end
 
     private

--- a/tasks/distrubution/travelling_ruby.rb
+++ b/tasks/distrubution/travelling_ruby.rb
@@ -15,10 +15,12 @@ module Distribution
       travelling_ruby.download_runtime
       travelling_ruby.extract_to_folder
       travelling_ruby.install_gems
+      travelling_ruby.install_native_extensions
+      travelling_ruby.cleanup_files
     end
 
     def install_gems
-      print_to_console 'Running `bundle install`...'
+      print_to_console 'Installing Gems...'
 
       Bundler.with_clean_env do
         FileUtils.cd "#{package.dir}/lib/app" do
@@ -33,6 +35,7 @@ module Distribution
 
     def extract_to_folder
       FileUtils.mkdir "#{package.dir}/lib/ruby"
+
       system(
         "tar -xzf packaging/traveling-ruby-#{package.rb_version}-" \
         "#{package.arch}.tar.gz " \
@@ -49,6 +52,31 @@ module Distribution
         unless File.exist? ruby
           curl "http://d6r77u77i8pq3.cloudfront.net/releases/#{ruby}"
         end
+      end
+    end
+
+    def install_native_extensions
+      FileUtils.mkdir_p "#{package.dir}/lib/vendor/ruby"
+
+      package.native_extensions.each do |ext|
+        FileUtils.cd "#{package.dir}/lib/vendor/ruby" do
+          curl 'http://d6r77u77i8pq3.cloudfront.net/releases/' \
+               "traveling-ruby-gems-#{package.rb_version}-#{package.arch}/" \
+               "#{ext}.tar.gz"
+
+          system "tar xzf #{ext}.tar.gz && rm #{ext}.tar.gz > /dev/null"
+        end
+      end
+    end
+
+    def cleanup_files
+      FileUtils.cd package.dir do
+        files  = Dir['**/{test,spec,doc,example,examples,features,benchmark}']
+        files += Dir['**/{tasks,Rakefile}']
+        files += Dir['lib/app/vendor/ruby/2.1.0/extensions/**/*']
+        files += Dir['lib/ruby/lib/ruby/**/darkfish/images/**/*']
+        files += Dir['**/*.{h,c,cpp,rl,java,class,md,rdoc,txt,gif}']
+        files.each { |file| FileUtils.rm_rf file }
       end
     end
   end


### PR DESCRIPTION
cc: @FooBarWidget

This adds the logic to get the native extensions and installs them. I install them to `lib/vendor/ruby` as mentioned in the writeup. Does this directory take precedence over other possible locations where gemfiles may be installed? I ask because I remove the extensions that are built from `bundle install`ing after downloading the Traveling Ruby extensions, and things seem to work. I want to make sure I am doing things correctly, however.