### PR TITLE
Fix Traveling Ruby tarball creation

### DIFF
--- a/tasks/distrubution/tarball.rb
+++ b/tasks/distrubution/tarball.rb
@@ -29,13 +29,14 @@ module Distribution
       FileUtils.mkdir_p 'distro'
       system "tar -czf distro/#{dir}.tar.gz #{dir} > /dev/null"
       FileUtils.remove_dir "#{dir}", true
+      File.open("distro/#{dir}.tar.gz", "rb")
     end
 
     private
 
     def search
       ball = Dir['distro/*.tar.gz'].find { |n| n.include? "#{arch}.tar.gz" }
-      File.new ball unless ball.nil?
+      File.open(ball, "rb") unless ball.nil?
     end
 
     def extract_version


### PR DESCRIPTION
The package task was broken because `build` didn't return a File object. This pull request fixes it. It also makes sure all files are opened in binary mode just to be sure there are no encoding issues.