### PR TITLE
Send content when connection is established on ws

### DIFF
--- a/lib/octodown/renderer/server.rb
+++ b/lib/octodown/renderer/server.rb
@@ -63,7 +63,10 @@ module Octodown
 
       def register_listener
         Octodown::Support::Services::Riposter.call file do
-          ws.send render_md
+          md = render_md
+          ws.on(:open) { ws.send md }
+          ws.send md
+
           puts "Reloading #{file.path}..."
         end
       end


### PR DESCRIPTION
Sometimes connections are lost between client and server, make sure we buffer
the requests so the user has an up to date version of the document when they
re-establish the connection.