### PR TITLE
Unshift the gem load path

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
 require 'octodown'
 require 'rack/test'
 


### PR DESCRIPTION
This is generally a good thing to do to ensure that in all environments, the gem path is loading the correct code.