### PR TITLE
Only pass links with href to relative_root_filter

### DIFF
--- a/lib/octodown/support/relative_root_filter.rb
+++ b/lib/octodown/support/relative_root_filter.rb
@@ -10,7 +10,7 @@ module Octodown
         @server = context[:server]
 
         filter_images doc.search('img')
-        filter_links doc.search('a')
+        filter_links doc.search('a[href]')
       end
 
       private

--- a/spec/support/test.md
+++ b/spec/support/test.md
@@ -11,4 +11,5 @@ def some_code()
 end
 ```
 
+<a name="anchor"></a>
 [some-file](test.txt)


### PR DESCRIPTION
Was crashing for anchors (link tags without href). Fixes #82

I added the previously crashing markup to test.md