### PR TITLE
Update the file handle upon each event

### DIFF
--- a/lib/octodown/renderer/server.rb
+++ b/lib/octodown/renderer/server.rb
@@ -120,8 +120,14 @@ module Octodown
       end
 
       def render_md(f)
-        f.rewind unless f.pos == 0
-        Renderer::GithubMarkdown.render f, options
+        begin
+          file_to_render = File.new(f.path, 'r')
+          f.close
+        rescue Errno::ENOENT
+          puts '[WARN] failed to read changes'
+          return
+        end
+        Renderer::GithubMarkdown.render file_to_render, options
       end
     end
   end # Support


### PR DESCRIPTION
Some text editors (vim, kate, etc) backup files on write.
The backup is done by renaming the original file and writing the
buffer to a new file with the original name.

This commit makes sure octodown reads the changes from the correct file.

Fixes ianks/octodown#90