### PR TITLE
Don't listen to removed file events

### DIFF
--- a/lib/octodown/renderer/github_markdown.rb
+++ b/lib/octodown/renderer/github_markdown.rb
@@ -20,11 +20,13 @@ module Octodown
         if file == STDIN
           buffer = file.read
         else
-          File.open(file.path, 'r') do |f|
-            buffer = f.read
+          begin
+            File.open(file.path, 'r') { |f| buffer = f.read }
+          rescue Errno::ENOENT
+            puts '[WARN] something went wrong when trying to open the file'
           end
         end
-        pipeline.call(buffer)[:output].to_s
+        pipeline.call(buffer ||= 'could not read changes')[:output].to_s
       end
 
       private

--- a/lib/octodown/support/services/riposter.rb
+++ b/lib/octodown/support/services/riposter.rb
@@ -8,8 +8,8 @@ module Octodown
           path = File.dirname(File.expand_path(file.path))
           regex = Regexp.new("^#{File.basename(file.path)}$")
 
-          @listener ||= Listen.to(path, only: regex) do
-            listener_callback.call
+          @listener ||= Listen.to(path, only: regex) do |modified, added, _rm|
+            listener_callback.call if modified.any? || added.any?
           end
 
           @listener.start

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -8,7 +8,7 @@ describe 'Integration' do
       octodown = File.join(__dir__, '..', 'bin', 'octodown')
       exec "TEST=1 bundle exec #{octodown} --live-reload #{dummy_path}"
     end
-    sleep 2
+    sleep 5
   end
 
   after :all do


### PR DESCRIPTION
With the new way we check for changes, sometimes octodown would fail
with file not found.

This was hard to catch, because it mostly depends on how fast the file
is written to the HD.

Listen was firing the callback when the file was removed (or renamed)
but since the callback tries to reopen that same file... it fails.

Fixed by not firing the callback on removals. It should still work on
renames, because we're still listening for added files.

related to ianks/octodown#90
