### PR TITLE
Fix hard line breaks in paragraphs

### DIFF
--- a/lib/octodown/renderer/github_markdown.rb
+++ b/lib/octodown/renderer/github_markdown.rb
@@ -37,7 +37,8 @@ module Octodown
           asset_root: 'https://assets-cdn.github.com/images/icons/',
           server: options[:presenter] == :server,
           original_document_root: document_root,
-          scope: 'highlight'
+          scope: 'highlight',
+          gfm: options[:gfm] || false
         }
       end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -26,8 +26,8 @@ describe 'Integration' do
       res = Net::HTTP.start 'localhost', 8887 do |http|
         http.request(Net::HTTP::Get.new('/'))
       end
-      expect(res.body).to include 'You are now reading markdown.'\
-                                  ' How lucky you are!'
+      expect(res.body).to include "You are now reading markdown.\n"\
+                                  "How lucky you are!"
     end
     it 'runs and receives data from the websocket' do
       message = nil
@@ -43,8 +43,8 @@ describe 'Integration' do
           end
         end
       end
-      expect(message).to include('You are now reading markdown.'\
-                                 ' How lucky you are!')
+      expect(message).to include("You are now reading markdown.\n"\
+                                 "How lucky you are!")
     end
   end
 

--- a/spec/support/test.md
+++ b/spec/support/test.md
@@ -3,7 +3,8 @@ Hello world!
 ![some-img](https://foo.com/bar.img)
 ![some-img](https://foo.com/bar.img)
 
-You are now reading markdown. How lucky you are!
+You are now reading markdown.
+How lucky you are!
 
 ```ruby
 def some_code()


### PR DESCRIPTION
To avoid hard line breaks getting inserted within paragraphs, the `gfm` context option has to be set explicitly to `false` in HTML::Pipeline. Do this, and amend the integration test to ensure this works correctly.

Rendering `README.md` in this repository before this change:
<img width="986" alt="octodown-before" src="https://user-images.githubusercontent.com/183430/51084448-b9cb9f80-1721-11e9-9028-0285b38c2340.png">

Rendering `README.md` in this repository after this change:
<img width="986" alt="octodown-after" src="https://user-images.githubusercontent.com/183430/51084455-ca7c1580-1721-11e9-880b-33ff7d5d0420.png">

This fixes #103.